### PR TITLE
add SmolLM2-1.7B

### DIFF
--- a/configs/_model/smollm2/1.7B.yaml
+++ b/configs/_model/smollm2/1.7B.yaml
@@ -1,0 +1,12 @@
+defaults:
+  - base_model
+  - _self_
+
+common:
+  dmodel: 2048
+  dff: 8192
+  dhead: 64
+  sequence_length: 2048
+  n_blocks: 24
+  q_heads: 32
+  kv_heads: 32

--- a/configs/_model/smollm2/base_model.yaml
+++ b/configs/_model/smollm2/base_model.yaml
@@ -1,0 +1,96 @@
+defaults:
+  - ../../ff_layer@model.encoder.block_fn.ff_layer_fn: dense
+  - _self_
+
+common:
+  _target_: src.definitions.Common
+  dmodel: ???
+  dff: ???
+  dhead: ???
+  sequence_length: ???
+  n_blocks: ???
+  q_heads: ???
+  kv_heads: ???
+
+
+model:
+  _target_: src.projected_compression.model.LLM
+
+  embedding:
+    _target_: src.projected_compression.model.TransformerEmbedding
+    vocab_size: 49152
+    dmodel: ${common.dmodel}
+    init_fn:
+      _target_: src.projected_compression.model.trunc_normal_
+      _partial_: true
+
+  encoder:
+    _target_: src.projected_compression.model.TransformerEncoder
+    n_blocks: ${common.n_blocks}
+    block_fn:
+      _target_: src.projected_compression.model.TransformerBlock
+      _partial_: true
+      norm_fn:
+        _target_: src.core.model.RMSNorm
+        _partial_: true
+        eps: 1e-5
+        normalized_shape: ${common.dmodel}
+
+      attention_fn:
+        _target_: src.projected_compression.model.RoPEAttention
+        _partial_: true
+        dmodel: ${common.dmodel}
+        q_heads: ${common.q_heads}
+        kv_heads: ${common.kv_heads}
+        seq_len: ${common.sequence_length}
+        q_proj_fn:
+          _target_: src.projected_compression.model.Linear
+          _partial_: true
+          in_features: ${common.dmodel}
+          out_features: ${eval:'${common.dhead} * ${model.encoder.block_fn.attention_fn.q_heads}'}
+          partial_init_fn:
+            _target_: src.projected_compression.model.llm_random_weight_init
+            _partial_: true
+            scale: 1
+
+        k_proj_fn:
+          _target_: src.projected_compression.model.Linear
+          _partial_: true
+          in_features: ${common.dmodel}
+          out_features: ${eval:'${common.dhead} * ${model.encoder.block_fn.attention_fn.kv_heads}'}
+          partial_init_fn:
+            _target_: src.projected_compression.model.llm_random_weight_init
+            _partial_: true
+            scale: 1
+
+        v_proj_fn: ${model.encoder.block_fn.attention_fn.k_proj_fn}
+
+        o_proj_fn:
+          _target_: src.projected_compression.model.Linear
+          _partial_: true
+          in_features: ${eval:'${common.dhead} * ${model.encoder.block_fn.attention_fn.q_heads}'}
+          out_features: ${common.dmodel}
+          partial_init_fn:
+            _target_: src.projected_compression.model.llm_random_weight_init
+            _partial_: true
+            scale: 1
+
+        rope_base: 130000
+        rope_scale_freqs: false
+
+  head:
+    _target_: src.projected_compression.model.TransformerHead
+    linear_fn:
+      _target_: src.projected_compression.model.Linear
+      _partial_: true
+      in_features: ${common.dmodel}
+      out_features: ${model.embedding.vocab_size}
+      partial_init_fn:
+        _target_: src.projected_compression.model.llm_random_weight_init
+        _partial_: true
+        scale: 1
+    norm_fn:
+      _target_: src.core.model.RMSNorm
+      _partial_: true
+      eps: 1e-5
+      normalized_shape: ${common.dmodel}

--- a/configs/_model/smollm2/base_pc_mem_eff.yaml
+++ b/configs/_model/smollm2/base_pc_mem_eff.yaml
@@ -1,0 +1,227 @@
+common:
+  dmodel: ???
+  dff: ???
+  dhead: ???
+  sequence_length: ???
+  base_dmodel: ???
+  base_dff: ???
+  n_blocks: ???
+  q_heads: ???
+  kv_heads: ???
+
+init_model_opt_sched_fn:
+  _target_: src.projected_compression.initialization.init_pc_attributes
+  _partial_: true
+
+projected_compression:
+  source_model_for_distillation: false
+
+
+model:
+  _target_: src.projected_compression.mem_eff.MemoryEfficientProjectedCompression
+
+  cast_bfloat16: true # whether to cast bfloat16 when calculating compressed matrix
+
+  source_model:
+    _target_: src.projected_compression.model.LLM
+    embedding:
+      _target_: src.projected_compression.model.Embedding
+      num_embeddings: 49152
+      embedding_dim: ${common.base_dmodel}
+
+    encoder:
+      _target_: src.projected_compression.model.TransformerEncoder
+      n_blocks: ${common.n_blocks}
+      block_fn:
+        _target_: src.projected_compression.model.TransformerBlock
+        _partial_: true
+        norm_fn:
+          _target_: src.core.model.RMSNorm
+          _partial_: true
+          eps: 1e-5
+          normalized_shape: ${common.base_dmodel}
+
+        attention_fn:
+          _target_: src.projected_compression.model.RoPEAttention
+          _partial_: true
+          dmodel: ${common.base_dmodel}
+          q_heads: ${common.q_heads}
+          kv_heads: ${common.kv_heads}
+          seq_len: ${common.sequence_length}
+          q_proj_fn:
+            _target_: src.projected_compression.model.Linear
+            _partial_: true
+            in_features: ${common.base_dmodel}
+            out_features: ${eval:'${common.dhead} * ${model.source_model.encoder.block_fn.attention_fn.q_heads}'}
+            partial_init_fn:
+              _target_: src.projected_compression.model.llm_random_weight_init
+              _partial_: true
+              scale: 1
+
+          k_proj_fn:
+            _target_: src.projected_compression.model.Linear
+            _partial_: true
+            in_features: ${common.base_dmodel}
+            out_features: ${eval:'${common.dhead} * ${model.source_model.encoder.block_fn.attention_fn.kv_heads}'}
+            partial_init_fn:
+              _target_: src.projected_compression.model.llm_random_weight_init
+              _partial_: true
+              scale: 1
+
+          v_proj_fn: ${model.source_model.encoder.block_fn.attention_fn.k_proj_fn}
+
+          o_proj_fn:
+            _target_: src.projected_compression.model.Linear
+            _partial_: true
+            in_features: ${eval:'${common.dhead} * ${model.source_model.encoder.block_fn.attention_fn.q_heads}'}
+            out_features: ${common.base_dmodel}
+            partial_init_fn:
+              _target_: src.projected_compression.model.llm_random_weight_init
+              _partial_: true
+              scale: 1
+
+          rope_base: 130000
+          rope_scale_freqs: false
+
+        ff_layer_fn:
+          _target_: src.projected_compression.model.ProjectedLlamaFeedForward
+          _partial_: true
+          ff_pre_act_fn:
+            _target_: src.projected_compression.model.Linear
+            _partial_: true
+            in_features: ${common.base_dmodel}
+            out_features: ${common.base_dff}
+            partial_init_fn:
+              _target_: src.projected_compression.model.llm_random_weight_init
+              _partial_: true
+              scale: 1
+          ff_post_act_fn:
+            _target_: src.projected_compression.model.Linear
+            _partial_: true
+            in_features: ${common.base_dff}
+            out_features: ${common.base_dmodel}
+            partial_init_fn:
+              _target_: src.projected_compression.model.llm_random_weight_init
+              _partial_: true
+              scale: 1
+          gate_fn: ${model.source_model.encoder.block_fn.ff_layer_fn.ff_pre_act_fn}
+
+    head:
+      _target_: src.projected_compression.model.TransformerHead
+      linear_fn:
+        _target_: src.projected_compression.model.Linear
+        _partial_: true
+        in_features: ${common.base_dmodel}
+        out_features: ${model.source_model.embedding.num_embeddings}
+        partial_init_fn:
+          _target_: src.projected_compression.model.llm_random_weight_init
+          _partial_: true
+          scale: 1
+      norm_fn:
+        _target_: src.core.model.RMSNorm
+        _partial_: true
+        eps: 1e-5
+        normalized_shape: ${common.base_dmodel}
+
+
+
+  target_model:
+    _target_: src.projected_compression.model.LLM
+    embedding:
+      _target_: src.projected_compression.model.Embedding
+      num_embeddings: 49152
+      embedding_dim: ${common.dmodel}
+
+    encoder:
+      _target_: src.projected_compression.model.TransformerEncoder
+      n_blocks: ${common.n_blocks}
+      block_fn:
+        _target_: src.projected_compression.model.TransformerBlock
+        _partial_: true
+        norm_fn:
+          _target_: src.core.model.RMSNorm
+          _partial_: true
+          eps: 1e-5
+          normalized_shape: ${common.dmodel}
+
+        attention_fn:
+          _target_: src.projected_compression.model.RoPEAttention
+          _partial_: true
+          dmodel: ${common.dmodel}
+          q_heads: ${common.q_heads}
+          kv_heads: ${common.kv_heads}
+          seq_len: ${common.sequence_length}
+          q_proj_fn:
+            _target_: src.projected_compression.model.Linear
+            _partial_: true
+            in_features: ${common.dmodel}
+            out_features: ${eval:'${common.dhead} * ${model.target_model.encoder.block_fn.attention_fn.q_heads}'}
+            partial_init_fn:
+              _target_: src.projected_compression.model.llm_random_weight_init
+              _partial_: true
+              scale: 1
+
+          k_proj_fn:
+            _target_: src.projected_compression.model.Linear
+            _partial_: true
+            in_features: ${common.dmodel}
+            out_features: ${eval:'${common.dhead} * ${model.target_model.encoder.block_fn.attention_fn.kv_heads}'}
+            partial_init_fn:
+              _target_: src.projected_compression.model.llm_random_weight_init
+              _partial_: true
+              scale: 1
+
+          v_proj_fn: ${model.target_model.encoder.block_fn.attention_fn.k_proj_fn}
+
+          o_proj_fn:
+            _target_: src.projected_compression.model.Linear
+            _partial_: true
+            in_features: ${eval:'${common.dhead} * ${model.target_model.encoder.block_fn.attention_fn.q_heads}'}
+            out_features: ${common.dmodel}
+            partial_init_fn:
+              _target_: src.projected_compression.model.llm_random_weight_init
+              _partial_: true
+              scale: 1
+
+          rope_base: 130000
+          rope_scale_freqs: false
+
+        ff_layer_fn:
+          _target_: src.projected_compression.model.ProjectedLlamaFeedForward
+          _partial_: true
+          ff_pre_act_fn:
+            _target_: src.projected_compression.model.Linear
+            _partial_: true
+            in_features: ${common.dmodel}
+            out_features: ${common.dff}
+            partial_init_fn:
+              _target_: src.projected_compression.model.llm_random_weight_init
+              _partial_: true
+              scale: 1
+          ff_post_act_fn:
+            _target_: src.projected_compression.model.Linear
+            _partial_: true
+            in_features: ${common.dff}
+            out_features: ${common.dmodel}
+            partial_init_fn:
+              _target_: src.projected_compression.model.llm_random_weight_init
+              _partial_: true
+              scale: 1
+          gate_fn: ${model.target_model.encoder.block_fn.ff_layer_fn.ff_pre_act_fn}
+
+    head:
+      _target_: src.projected_compression.model.TransformerHead
+      linear_fn:
+        _target_: src.projected_compression.model.Linear
+        _partial_: true
+        in_features: ${common.dmodel}
+        out_features: ${model.target_model.embedding.num_embeddings}
+        partial_init_fn:
+          _target_: src.projected_compression.model.llm_random_weight_init
+          _partial_: true
+          scale: 1
+      norm_fn:
+        _target_: src.core.model.RMSNorm
+        _partial_: true
+        eps: 1e-5
+        normalized_shape: ${common.dmodel}

--- a/configs/_model/smollm2/projected_mem_eff_1.7B.yaml
+++ b/configs/_model/smollm2/projected_mem_eff_1.7B.yaml
@@ -1,0 +1,14 @@
+defaults:
+  - base_pc_mem_eff
+  - _self_
+
+common:
+  dmodel: 1344 # ~50% parameter compression
+  dff: 5376 # ~50% parameter compression
+  dhead: 64
+  sequence_length: 512
+  base_dmodel: 2048
+  base_dff: 8192
+  n_blocks: 24
+  q_heads: 32
+  kv_heads: 32

--- a/configs/_trainer/smollm2.yaml
+++ b/configs/_trainer/smollm2.yaml
@@ -1,0 +1,35 @@
+
+trainer:
+  _partial_: true
+  _target_: src.core.trainer.Trainer
+  eval_interval: 100
+  n_eval_steps: 10
+  gradient_accumulation_steps: 1
+  gradient_clipping: 1.0
+  n_steps: null
+  learning_rate: null
+  weight_decay: 0.1
+
+  scheduler:
+    _partial_: true
+    _target_: src.core.schedulers.get_cosine_scheduler_with_warmup
+    final_lr_fraction: 0.1
+    warmup_steps: ${eval:'int(${trainer.n_steps} * 0.01)'}
+
+  distributed:
+    fsdp2:
+      modules_to_shard:
+        - ${model.embedding._target_}
+        - ${model.encoder.block_fn._target_}
+        - ${model.head._target_}
+
+  train_dataloader:
+    dataset:
+      tokenize_fn:
+        _target_: src.core.datasets.smollm2_tokenize_fn
+
+
+  eval_dataloader:
+    dataset:
+      tokenize_fn:
+        _target_: src.core.datasets.smollm2_tokenize_fn

--- a/configs/_trainer/smollm2_1.7B_distillation.yaml
+++ b/configs/_trainer/smollm2_1.7B_distillation.yaml
@@ -1,0 +1,16 @@
+
+defaults:
+  - smollm2_distillation
+
+common_distillation:
+  dmodel: 2048
+  dff: 8192
+  dhead: 64
+  n_blocks: 24
+  q_heads: 32
+  kv_heads: 32
+  vocab_size: 49152
+
+distillation:
+  load:
+    path: "HuggingFaceTB/SmolLM2-1.7B"

--- a/configs/_trainer/smollm2_distillation.yaml
+++ b/configs/_trainer/smollm2_distillation.yaml
@@ -1,0 +1,163 @@
+
+common_distillation:
+  dmodel: ???
+  dff: ???
+  dhead: ???
+  n_blocks: ???
+  q_heads: ???
+  kv_heads: ???
+  vocab_size: ???
+
+distillation:
+  load:
+    type: huggingface_smollm
+    path: ???
+
+  teacher_model:
+    _target_: src.projected_compression.model.LLM
+
+    embedding:
+      _target_: src.projected_compression.model.TransformerEmbedding
+      vocab_size: ${common_distillation.vocab_size}
+      dmodel: ${common_distillation.dmodel}
+      init_fn:
+        _target_: src.projected_compression.model.trunc_normal_
+        _partial_: true
+
+    encoder:
+      _target_: src.projected_compression.model.TransformerEncoder
+      n_blocks: ${common_distillation.n_blocks}
+      block_fn:
+        _target_: src.projected_compression.model.TransformerBlock
+        _partial_: true
+        norm_fn:
+          _target_: src.core.model.RMSNorm
+          _partial_: true
+          eps: 1e-5
+          normalized_shape: ${common_distillation.dmodel}
+
+        attention_fn:
+          _target_: src.projected_compression.model.RoPEAttention
+          _partial_: true
+          dmodel: ${common_distillation.dmodel}
+          q_heads: ${common_distillation.q_heads}
+          kv_heads: ${common_distillation.kv_heads}
+          seq_len: ${common.sequence_length}
+          q_proj_fn:
+            _target_: src.projected_compression.model.Linear
+            _partial_: true
+            in_features: ${common_distillation.dmodel}
+            out_features: ${eval:'${common_distillation.dhead} * ${distillation.teacher_model.encoder.block_fn.attention_fn.q_heads}'}
+            partial_init_fn:
+              _target_: src.projected_compression.model.llm_random_weight_init
+              _partial_: true
+              scale: 1
+
+          k_proj_fn:
+            _target_: src.projected_compression.model.Linear
+            _partial_: true
+            in_features: ${common_distillation.dmodel}
+            out_features: ${eval:'${common_distillation.dhead} * ${distillation.teacher_model.encoder.block_fn.attention_fn.kv_heads}'}
+            partial_init_fn:
+              _target_: src.projected_compression.model.llm_random_weight_init
+              _partial_: true
+              scale: 1
+
+          v_proj_fn: ${distillation.teacher_model.encoder.block_fn.attention_fn.k_proj_fn}
+
+          o_proj_fn:
+            _target_: src.projected_compression.model.Linear
+            _partial_: true
+            in_features: ${eval:'${common_distillation.dhead} * ${distillation.teacher_model.encoder.block_fn.attention_fn.q_heads}'}
+            out_features: ${common_distillation.dmodel}
+            partial_init_fn:
+              _target_: src.projected_compression.model.llm_random_weight_init
+              _partial_: true
+              scale: 1
+
+          rope_base: 130000
+          rope_scale_freqs: false
+
+        ff_layer_fn:
+          _target_: src.projected_compression.model.ProjectedLlamaFeedForward
+          _partial_: true
+          ff_pre_act_fn:
+            _target_: src.projected_compression.model.Linear
+            _partial_: true
+            in_features: ${common_distillation.dmodel}
+            out_features: ${common_distillation.dff}
+            partial_init_fn:
+              _target_: src.projected_compression.model.llm_random_weight_init
+              _partial_: true
+              scale: 1
+          ff_post_act_fn:
+            _target_: src.projected_compression.model.Linear
+            _partial_: true
+            in_features: ${common_distillation.dff}
+            out_features: ${common_distillation.dmodel}
+            partial_init_fn:
+              _target_: src.projected_compression.model.llm_random_weight_init
+              _partial_: true
+              scale: 1
+          gate_fn: ${distillation.teacher_model.encoder.block_fn.ff_layer_fn.ff_pre_act_fn}
+
+    head:
+      _target_: src.projected_compression.model.TransformerHead
+      linear_fn:
+        _target_: src.projected_compression.model.Linear
+        _partial_: true
+        in_features: ${common_distillation.dmodel}
+        out_features: ${common_distillation.vocab_size}
+        partial_init_fn:
+          _target_: src.projected_compression.model.llm_random_weight_init
+          _partial_: true
+          scale: 1
+      norm_fn:
+        _target_: src.core.model.RMSNorm
+        _partial_: true
+        eps: 1e-5
+        normalized_shape: ${common_distillation.dmodel}
+
+trainer:
+  _partial_: true
+  _target_: src.core.trainer_distillation.TrainerDistillation
+  distillation_alpha: 0.5
+  distillation_temperature: 1.0
+  distillation_loss_num_chunks: 8  # split the vocab loss over N token chunks to cap peak memory
+  eval_interval: 100
+  n_eval_steps: 10
+  gradient_accumulation_steps: 1
+  gradient_clipping: 1.0
+  n_steps: null
+  learning_rate: null
+  weight_decay: 0.1
+
+  scheduler:
+    _partial_: true
+    _target_: src.core.schedulers.get_cosine_scheduler_with_warmup
+    final_lr_fraction: 0.1
+    warmup_steps: ${eval:'int(${trainer.n_steps} * 0.01)'}
+
+  teacher_distributed:
+    fsdp2:
+      modules_to_shard:
+        - ${distillation.teacher_model.embedding._target_}
+        - ${distillation.teacher_model.encoder.block_fn._target_}
+        - ${distillation.teacher_model.head._target_}
+
+  distributed:
+    fsdp2:
+      modules_to_shard:
+        - ${model.embedding._target_}
+        - ${model.encoder.block_fn._target_}
+        - ${model.head._target_}
+
+  train_dataloader:
+    dataset:
+      tokenize_fn:
+        _target_: src.core.datasets.smollm2_tokenize_fn
+
+  eval_dataloader:
+    dataset:
+      tokenize_fn:
+        _target_: src.core.datasets.smollm2_tokenize_fn

--- a/configs/pc_project/smollm2/smollm2_conversion.yaml
+++ b/configs/pc_project/smollm2/smollm2_conversion.yaml
@@ -1,0 +1,42 @@
+# notebook for producing a PC checkpoint used for PC_memeff training
+
+defaults:
+  - ../../_misc@_here_: default
+  - ../../_cluster@_here_: lem
+  - ../../_model/smollm2@_here_: 1.7B
+  - _self_
+
+
+trainer:
+  checkpoint:
+    load:
+      type: huggingface
+      path: "HuggingFaceTB/SmolLM2-1.7B"
+
+    save:
+      path: /lustre/pd03/plgrid/plgllmefficont3/plgj321m/pc/smollm2_1_7b_in_nano.pt # CHANGE
+
+infrastructure:
+  metric_logger:
+    name: PC_save_pretrained_hf_to_nano
+    tags:
+      - nano
+      - pc
+      - save_pretrained
+      - smollm2
+
+  slurm:
+    job-name: ${infrastructure.metric_logger.name}
+    gres: gpu:hopper:1
+    time: "0-01:00:00"
+
+init_model_opt_sched_fn:
+  _target_: src.core.smollm.save_pretrained_smollm_as_nano
+  _partial_: true
+
+# verify converted nano model matches HF logits; comment out to switch off
+apply_functions:
+  - _target_: src.core.smollm.verify_smollm_against_hf
+    _partial_: true
+    hf_path: ${trainer.checkpoint.load.path}
+    vocab_size: ${model.embedding.vocab_size}

--- a/configs/pc_project/smollm2/smollm2_hp_distil.yaml
+++ b/configs/pc_project/smollm2/smollm2_hp_distil.yaml
@@ -1,0 +1,73 @@
+defaults:
+  - ../../_cluster@_here_: lem
+  - ../../_model/smollm2@_here_: 1.7B
+  - ../../_trainer@_here_: smollm2_1.7B_distillation
+  - ../../_dataset@_here_: fineweb
+  - ../../_checkpoints@_here_: none
+  - ../../_misc@_here_: default
+
+
+common:
+  sequence_length: 1024
+  batch_size: 512
+
+  # base: dmodel 2048, dff 8192
+  ^target_dmodel: [448, 960, 1344]
+  target_dff: "${eval:'${common.target_dmodel} * 4'}"
+
+
+trainer:
+  gradient_accumulation_steps: 8
+  ^n_steps:
+    # - 2048 # 1B tokens  <4.5h
+    - 4096 # 2B tokens    <9h
+    - 8192 # 4B tokens    <18h
+    - 16384 # 8B tokens   <36h
+
+  learning_rate: 11
+
+  scheduler:
+    warmup_steps: 40
+
+  original_llama_path: HuggingFaceTB/SmolLM2-1.7B # reference HF model for the exporter
+
+  checkpoint:
+    load:
+      type: huggingface_smollm
+      path: "HuggingFaceTB/SmolLM2-1.7B"
+    save:
+      type: hf_only
+      path: /lustre/pd03/plgrid/plgllmefficont3/plgj321m/pc/checkpoints/hp_distil/smollm2/1_7B # CHANGE
+
+  eval_interval: 0
+  eval_dataloader: None
+  train_dataloader:
+    dataset:
+      seed: 1000
+
+
+infrastructure:
+  metric_logger:
+    name: SmolLM2_HP
+    tags:
+      - nano
+      - pc
+      - smollm2
+      - 1.7B
+      - hard_pruning
+      - distillation
+      - "${eval:'{2048:\"1B_train\",4096:\"2B_train\",8192:\"4B_train\",16384:\"8B_train\"}[${trainer.n_steps}]'}"
+      - "${eval:'{448:\"10p\",960:\"30p\",1344:\"50p\"}[${common.target_dmodel}]'}"
+
+  slurm:
+    job-name: ${infrastructure.metric_logger.name}
+    gres: gpu:hopper:4
+    time: "2-00:00:00"
+
+
+apply_functions:
+  - _target_: src.projected_compression.pruning.prune
+    _partial_: true
+    dimensions_importances_path: /lustre/pd03/plgrid/plgllmefficont3/plgj321m/pc/importances/smollm2/1_7B/minitron_dimensions_importances.pt # CHANGE - from smollm2_importances
+    target_dmodel: ${common.target_dmodel}
+    target_dff: ${common.target_dff}

--- a/configs/pc_project/smollm2/smollm2_hp_lm.yaml
+++ b/configs/pc_project/smollm2/smollm2_hp_lm.yaml
@@ -1,0 +1,70 @@
+defaults:
+  - ../../_cluster@_here_: lem
+  - ../../_model/smollm2@_here_: 1.7B
+  - ../../_trainer@_here_: smollm2
+  - ../../_dataset@_here_: fineweb
+  - ../../_checkpoints@_here_: none
+  - ../../_misc@_here_: default
+
+
+common:
+  sequence_length: 1024
+  batch_size: 512
+
+  # base: dmodel 2048, dff 8192
+  ^target_dmodel: [448, 960, 1344]
+  target_dff: "${eval:'${common.target_dmodel} * 4'}"
+
+
+trainer:
+  gradient_accumulation_steps: 8
+  ^n_steps:
+    # - 2048 # 1B tokens  <3h
+    - 4096 # 2B tokens    <6h
+    - 8192 # 4B tokens    <12h
+    - 16384 # 8B tokens   <24h
+
+  learning_rate: 11
+
+  scheduler:
+    warmup_steps: 40
+
+  original_llama_path: HuggingFaceTB/SmolLM2-1.7B # reference HF model for the exporter
+
+  checkpoint:
+    load:
+      type: huggingface_smollm
+      path: "HuggingFaceTB/SmolLM2-1.7B"
+    save:
+      type: hf_only
+      path: /lustre/pd03/plgrid/plgllmefficont3/plgj321m/pc/checkpoints/hp/smollm2/1_7B # CHANGE
+
+  eval_interval: 0
+  eval_dataloader: None
+
+
+infrastructure:
+  metric_logger:
+    name: SmolLM2_HP
+    tags:
+      - nano
+      - pc
+      - smollm2
+      - 1.7B
+      - hard_pruning
+      - lm_retraining
+      - "${eval:'{2048:\"1B_train\",4096:\"2B_train\",8192:\"4B_train\",16384:\"8B_train\"}[${trainer.n_steps}]'}"
+      - "${eval:'{448:\"10p\",960:\"30p\",1344:\"50p\"}[${common.target_dmodel}]'}"
+
+  slurm:
+    job-name: ${infrastructure.metric_logger.name}
+    gres: gpu:hopper:4
+    time: "2-00:00:00"
+
+
+apply_functions:
+  - _target_: src.projected_compression.pruning.prune
+    _partial_: true
+    dimensions_importances_path: /lustre/pd03/plgrid/plgllmefficont3/plgj321m/pc/importances/smollm2/1_7B/minitron_dimensions_importances.pt # CHANGE - from smollm2_importances
+    target_dmodel: ${common.target_dmodel}
+    target_dff: ${common.target_dff}

--- a/configs/pc_project/smollm2/smollm2_importances.yaml
+++ b/configs/pc_project/smollm2/smollm2_importances.yaml
@@ -1,0 +1,72 @@
+defaults:
+  - ../../_cluster@_here_: lem
+  - ../../_model/smollm2@_here_: 1.7B
+  - ../../_trainer@_here_: smollm2
+  - ../../_dataset@_here_: fineweb
+  - ../../_checkpoints@_here_: none
+  - ../../_misc@_here_: default
+
+
+common:
+  sequence_length: 1024
+  batch_size: 4
+
+
+trainer:
+  gradient_accumulation_steps: 8 # not used ?
+  n_steps: 0 # not used
+  learning_rate: 1 # not used
+
+  checkpoint:
+    load:
+      type: huggingface_smollm
+      path: "HuggingFaceTB/SmolLM2-1.7B"
+
+    save:
+      type: nano
+      path: /lustre/pd03/plgrid/plgllmefficont3/plgj321m/pc/importances/smollm2/1_7B # CHANGE
+
+
+infrastructure:
+  metric_logger:
+    name: SmolLM2_importances
+    tags:
+      - nano
+      - pc
+      - smollm2
+      - 1.7B
+      - IMPORTANCES
+      - fineweb
+
+  slurm:
+    job-name: importances_smollm2
+    gres: gpu:hopper:1
+    nodes: 1
+    time: "0-2:00:00"
+
+
+apply_functions:
+  - _target_: src.projected_compression.weight_importances.dummy_importances
+    _partial_: true
+    dmodel: ${common.dmodel}
+    dff: ${common.dff}
+    n_blocks: ${model.encoder.n_blocks}
+    checkpoint_save_path: ${trainer.checkpoint.save.path}
+  - _target_: src.projected_compression.weight_importances.minitron_importances
+    _partial_: true
+    dataloader: ${trainer.train_dataloader}
+    dmodel: ${common.dmodel}
+    dff: ${common.dff}
+    calibration_dataset_size: 8192 # nvidia used 2k steps of 4k sequence lenght - this is the saturaion poin - longer doesnt improve miningfully
+    seq_len: ${common.sequence_length}
+    total_batch_size: ${trainer.train_dataloader.total_batch_size}
+    n_blocks: ${model.encoder.n_blocks}
+    checkpoint_save_path: ${trainer.checkpoint.save.path}
+  - _target_: src.projected_compression.weight_importances.magnitude_importances
+    _partial_: true
+    dmodel: ${common.dmodel}
+    dff: ${common.dff}
+    n_blocks: ${model.encoder.n_blocks}
+    checkpoint_save_path: ${trainer.checkpoint.save.path}
+  - _target_: src.core.utils.finish_exp
+    _partial_: true

--- a/configs/pc_project/smollm2/smollm2_pc_distil.yaml
+++ b/configs/pc_project/smollm2/smollm2_pc_distil.yaml
@@ -1,0 +1,98 @@
+defaults:
+  - ../../_cluster@_here_: lem
+  - ../../_model/smollm2@_here_: projected_mem_eff_1.7B
+  - ../../_trainer@_here_: smollm2_1.7B_distillation
+  - ../../_dataset@_here_: fineweb
+  - ../../_checkpoints@_here_: none
+  - ../../_misc@_here_: default
+
+common:
+  sequence_length: 1024
+  batch_size: 512
+
+  # base: dmodel 2048, dff 8192
+  ^dmodel: [448, 960, 1344]
+  dff: "${eval:'${common.dmodel} * 4'}"
+
+
+trainer:
+  _target_: src.projected_compression.trainer_distillation.PCDistillationTrainer
+  gradient_accumulation_steps: 8
+  ^n_steps:
+    - 2048 # 1B tokens  <5h
+    # - 4096 # 2B tokens    <10h
+    # - 8192 # 4B tokens    <20h
+    # - 16384 # 8B tokens   <40h
+
+  gradient_clipping: 0.25 #best
+  only_compress_model_gradient_clipping: false
+  only_target_model_gradient_clipping: 1.0 #best
+
+  learning_rate: 14
+
+  scheduler:
+    warmup_steps: 40
+
+  distributed:
+    fsdp2: null
+
+  original_llama_path: HuggingFaceTB/SmolLM2-1.7B # reference HF model for the exporter
+
+  eval_interval: 0 # PC_memeff does not work in eval inference mode
+  eval_dataloader: None
+
+  checkpoint: # only way to save PC_memeff model
+    save:
+      interval: 0  # 0 = only save at the end of training
+      model_checkpoint_filename: __model_checkpoint_filename.pt
+      path: /lustre/pd03/plgrid/plgllmefficont3/plgj321m/pc/checkpoints/pc_distil/smollm2/1_7B # CHANGE
+      training_state_filename: __training_state_filename.pt
+      type: hf_only
+
+projected_compression:
+  modules_to_shard:
+    - src.projected_compression.mem_eff.CompressibleBlock
+    - ${model.source_model.embedding._target_}
+    - ${model.source_model.encoder.block_fn._target_}
+    - ${model.source_model.head._target_}
+
+  source_model_path: /lustre/pd03/plgrid/plgllmefficont3/plgj321m/pc/smollm2_1_7b_in_nano.pt # CHANGE - from smollm2_conversion
+  path_to_importances: /lustre/pd03/plgrid/plgllmefficont3/plgj321m/pc/importances/smollm2/1_7B/minitron_dimensions_importances.pt # CHANGE - from smollm2_importances
+
+  init_norms_with_ones: false
+
+  separate_block_optimizers: true
+
+  pc_weights_lr_ratio: 1.0 # lr multiplier for projection matrices (not aux weights)
+
+  adjust_grad_norm: false
+
+  cpu_offload_projections: false
+
+  source_model_for_distillation: true
+
+distillation:
+  load:
+    type: pc_memeff_base # uses internal teacher model representation for distillation to save memory - source_model_for_distillation: true
+
+model:
+  cast_bfloat16: true # whether to cast bfloat16 when calculating compressed matrix
+
+infrastructure:
+  metric_logger:
+    name: SmolLM2_PC
+    tags:
+      - nano
+      - pc
+      - smollm2
+      - 1.7B
+      - projected_compression
+      - distillation
+      - "${eval:'{2048:\"1B_train\",4096:\"2B_train\",8192:\"4B_train\",16384:\"8B_train\"}[${trainer.n_steps}]'}"
+      - mem_eff
+      - "${eval:'{448:\"10p\",960:\"30p\",1344:\"50p\"}[${common.dmodel}]'}"
+
+  slurm:
+    job-name: ${infrastructure.metric_logger.name}
+    gres: gpu:hopper:4
+    time: "2-12:00:00"

--- a/configs/pc_project/smollm2/smollm2_pc_lm.yaml
+++ b/configs/pc_project/smollm2/smollm2_pc_lm.yaml
@@ -1,0 +1,90 @@
+defaults:
+  - ../../_cluster@_here_: lem
+  - ../../_model/smollm2@_here_: projected_mem_eff_1.7B
+  - ../../_trainer@_here_: smollm2
+  - ../../_dataset@_here_: fineweb
+  - ../../_checkpoints@_here_: none
+  - ../../_misc@_here_: default
+
+common:
+  sequence_length: 1024
+  batch_size: 512
+
+  # base: dmodel 2048, dff 8192
+  ^dmodel: [448, 960, 1344]
+  dff: "${eval:'${common.dmodel} * 4'}"
+
+
+trainer:
+  _target_: src.projected_compression.trainer.PCTrainer
+  gradient_accumulation_steps: 8
+  ^n_steps:
+    - 2048 # 1B tokens  <3h
+    # - 4096 # 2B tokens    <6h
+    # - 8192 # 4B tokens    <12h
+    # - 16384 # 8B tokens   <24h
+
+  gradient_clipping: 1.0 # match HP baseline clip
+  only_compress_model_gradient_clipping: false
+  only_target_model_gradient_clipping: 1.0 #best
+
+  learning_rate: 13
+
+  scheduler:
+    warmup_steps: 40
+
+  distributed:
+    fsdp2: null
+
+  eval_dataloader: None
+  eval_interval: 0
+
+  original_llama_path: HuggingFaceTB/SmolLM2-1.7B
+  checkpoint:
+    save: #switch
+      interval: 0  # 0 = only save at the end of training
+      path: /lustre/pd03/plgrid/plgllmefficont3/plgj321m/pc/checkpoints/pc/smollm2/1_7B # CHANGE
+      training_state_filename: __training_state_filename.pt
+      type: hf_only  # "nano" | "hf_only" | "nano_and_hf"
+
+projected_compression:
+  modules_to_shard:
+    - src.projected_compression.mem_eff.CompressibleBlock
+    - ${model.source_model.embedding._target_}
+    - ${model.source_model.encoder.block_fn._target_}
+    - ${model.source_model.head._target_}
+
+  source_model_path: /lustre/pd03/plgrid/plgllmefficont3/plgj321m/pc/smollm2_1_7b_in_nano.pt # CHANGE - from smollm2_conversion
+  path_to_importances: /lustre/pd03/plgrid/plgllmefficont3/plgj321m/pc/importances/smollm2/1_7B/minitron_dimensions_importances.pt # CHANGE - from smollm2_importances
+
+  init_norms_with_ones: false
+
+  separate_block_optimizers: true
+
+  adjust_grad_norm: false
+
+  cpu_offload_projections: false
+
+
+model:
+  cast_bfloat16: false
+
+infrastructure:
+  metric_logger:
+    name: SmolLM2_PC
+    tags:
+      - nano
+      - pc
+      - smollm2
+      - 1.7B
+      - projected_compression
+      - mem_eff
+      - "${eval:'{2048:\"1B_train\",4096:\"2B_train\",8192:\"4B_train\",16384:\"8B_train\"}[${trainer.n_steps}]'}"
+      - lm_retraining
+      - "${eval:'{448:\"10p\",960:\"30p\",1344:\"50p\"}[${common.dmodel}]'}"
+      - fp32
+
+  slurm:
+    job-name: ${infrastructure.metric_logger.name}
+    gres: gpu:hopper:4
+    time: "1-00:00:00"

--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ from src.core.distributed_training import setup_distributed_training
 from src.core.conversion_from_llmrandom import load_llmrandom_checkpoint
 from src.core.llama import copy_llama_model_weights_from_HF
 from src.core.qwen import copy_qwen_model_weights_from_HF
+from src.core.smollm import copy_smollm_model_weights_from_HF
 from grid_generator.generate_configs import create_grid_config
 from grid_generator.sbatch_builder import generate_sbatch_script
 import resolver as _  # I should be able to ignore this line by linter, but ~ things like # ignore did not work
@@ -268,6 +269,11 @@ def initialize_training_components(cfg: OmegaConf, metric_logger=None):
         model, optimizer, scheduler = get_model_optimizer_scheduler(
             cfg, model, learning_rate
         )
+    elif cfg.trainer.checkpoint.load.type == "huggingface_smollm":
+        copy_smollm_model_weights_from_HF(model, cfg.trainer.checkpoint.load.path)
+        model, optimizer, scheduler = get_model_optimizer_scheduler(
+            cfg, model, learning_rate
+        )
     elif cfg.trainer.checkpoint.load.type == "llm-random":
         load_llmrandom_checkpoint(cfg.trainer.checkpoint.load, model)
         model, optimizer, scheduler = get_model_optimizer_scheduler(
@@ -325,12 +331,20 @@ def run(cfg: OmegaConf, metric_logger=None):
         trainer = instantiate(cfg.trainer)
 
         if "distillation" in cfg:
-            if cfg.distillation.load.type in ["huggingface", "huggingface_qwen"]:
+            if cfg.distillation.load.type in [
+                "huggingface",
+                "huggingface_qwen",
+                "huggingface_smollm",
+            ]:
                 teacher_model = instantiate(
                     cfg.distillation.teacher_model, _convert_="all"
                 ).to(get_device())
                 if cfg.distillation.load.type == "huggingface_qwen":
                     copy_qwen_model_weights_from_HF(
+                        teacher_model, cfg.distillation.load.path
+                    )
+                elif cfg.distillation.load.type == "huggingface_smollm":
+                    copy_smollm_model_weights_from_HF(
                         teacher_model, cfg.distillation.load.path
                     )
                 else:

--- a/src/core/datasets.py
+++ b/src/core/datasets.py
@@ -70,6 +70,25 @@ def qwen_tokenize_fn():
     return tokenize_function
 
 
+def smollm2_tokenize_fn():
+    tokenizer = AutoTokenizer.from_pretrained(
+        "HuggingFaceTB/SmolLM2-1.7B",
+        add_bos_token=True,
+        add_eos_token=True,
+        legacy=False,
+    )
+
+    def tokenize_function(examples):
+        batch_encodings = tokenizer(
+            examples["text"],
+            truncation=False,
+            max_length=int(1e10),
+        )
+        return batch_encodings
+
+    return tokenize_function
+
+
 def smollm_135_tokenize_fn():
     tokenizer = AutoTokenizer.from_pretrained(
         "HuggingFaceTB/SmolLM-135M",

--- a/src/core/smollm.py
+++ b/src/core/smollm.py
@@ -1,0 +1,75 @@
+from collections import OrderedDict
+
+import torch
+from omegaconf import OmegaConf
+from hydra.utils import instantiate
+from transformers import AutoModelForCausalLM
+
+from .llama import remap_llamahf_state_dict_to_nano
+
+
+def remap_smollm2hf_state_dict_to_nano(smollm_state_dict):
+    # SmolLM2 is a plain Llama architecture; reuse the Llama remap.
+    remapped = remap_llamahf_state_dict_to_nano(smollm_state_dict)
+    # SmolLM2 ties lm_head to the input embedding, so HF may omit lm_head.weight.
+    if "head.linear.weight" not in remapped and "embedding.weight" in remapped:
+        remapped["head.linear.weight"] = remapped["embedding.weight"]
+    return OrderedDict(remapped)
+
+
+def copy_smollm_model_weights_from_HF(model, path):
+    hf_model = AutoModelForCausalLM.from_pretrained(path)
+    remapped_state_dict = remap_smollm2hf_state_dict_to_nano(hf_model.state_dict())
+    model.load_state_dict(remapped_state_dict)
+
+
+def save_pretrained_smollm_as_nano(cfg: OmegaConf, metric_logger=None):
+
+    hf_model = AutoModelForCausalLM.from_pretrained(cfg.trainer.checkpoint.load.path)
+    nano_sd = remap_smollm2hf_state_dict_to_nano(hf_model.state_dict())
+    # PC mem-eff projections run in fp32 (cast_bfloat16=false); SmolLM2 loads as bf16
+    # by default, so cast here to match the Llama pipeline's fp32 checkpoint
+    nano_sd = OrderedDict((k, v.float()) for k, v in nano_sd.items())
+
+    model = instantiate(cfg.model, _convert_="all")
+    weights = {k for k in model.state_dict() if not k.endswith((".sin", ".cos"))}
+    missing = weights - set(nano_sd)
+    if missing:
+        raise RuntimeError(f"SmolLM2->nano remap left weights unfilled: {sorted(missing)}")
+
+    model.load_state_dict(nano_sd, strict=False, assign=True)
+
+    torch.save(model.state_dict(), cfg.trainer.checkpoint.save.path)
+
+    if cfg.get("apply_functions", None):
+        for fn in instantiate(cfg.apply_functions):
+            fn(model)
+
+    return None, None, None, None, None
+
+
+def verify_smollm_against_hf(model, hf_path, vocab_size, seq_len=256, min_agreement=0.99):
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    hf_model = AutoModelForCausalLM.from_pretrained(hf_path).to(device).eval().float()
+    model = model.to(device).eval().float()
+
+    torch.manual_seed(0)
+    input_ids = torch.randint(0, vocab_size, (1, seq_len), device=device)
+
+    with torch.no_grad():
+        nano_logits = model(input_ids)
+        hf_logits = hf_model(input_ids).logits
+
+    max_abs_diff = (nano_logits - hf_logits).abs().max().item()
+    argmax_agreement = (
+        (nano_logits.argmax(-1) == hf_logits.argmax(-1)).float().mean().item()
+    )
+    print(
+        f"[verify] max_abs_logit_diff={max_abs_diff:.4g} "
+        f"argmax_agreement={argmax_agreement:.4f} over {seq_len} positions"
+    )
+    if argmax_agreement < min_agreement:
+        raise RuntimeError(
+            f"SmolLM2->nano verification failed: argmax_agreement={argmax_agreement:.4f} "
+            f"< {min_agreement} (max_abs_logit_diff={max_abs_diff:.4g})"
+        )


### PR DESCRIPTION
SmolLM2-1.7B is a plain Llama architecture. Adds:
- src/core/smollm.py: HF->nano remap (reuses llama remap + tied-embedding fallback), copy/save_pretrained/verify helpers
- main.py: huggingface_smollm load dispatch (LM + distillation teacher)
- datasets.py: smollm2_tokenize_fn
- configs/_model/smollm2/, configs/_trainer/smollm2*, configs/pc_project/smollm2/ (conversion, importances, pc_lm, pc_distil, hp_lm, hp_distil) mirroring qwen

Verified locally (no cluster): 1.7B nano config matches HF config.json; SmolLM2-135M end-to-end logit match exact (argmax_agreement=1.0); PC source/ target sub-models instantiate and forward.