### PR TITLE
add OLMo-2-0425-1B

### DIFF
--- a/configs/_model/olmo/1B.yaml
+++ b/configs/_model/olmo/1B.yaml
@@ -1,0 +1,12 @@
+defaults:
+  - base_model
+  - _self_
+
+common:
+  dmodel: 2048
+  dff: 8192
+  dhead: 128
+  sequence_length: 4096
+  n_blocks: 16
+  q_heads: 16
+  kv_heads: 16

--- a/configs/_model/olmo/base_model.yaml
+++ b/configs/_model/olmo/base_model.yaml
@@ -1,0 +1,108 @@
+defaults:
+  - ../../ff_layer@model.encoder.block_fn.ff_layer_fn: dense
+  - _self_
+
+common:
+  _target_: src.definitions.Common
+  dmodel: ???
+  dff: ???
+  dhead: ???
+  sequence_length: ???
+  n_blocks: ???
+  q_heads: ???
+  kv_heads: ???
+
+
+model:
+  _target_: src.projected_compression.model.LLM
+
+  embedding:
+    _target_: src.projected_compression.model.TransformerEmbedding
+    vocab_size: 100352
+    dmodel: ${common.dmodel}
+    init_fn:
+      _target_: src.projected_compression.model.trunc_normal_
+      _partial_: true
+
+  encoder:
+    _target_: src.projected_compression.model.TransformerEncoder
+    n_blocks: ${common.n_blocks}
+    block_fn:
+      _target_: src.projected_compression.model.OlmoTransformerBlock
+      _partial_: true
+      norm_fn:
+        _target_: src.core.model.RMSNorm
+        _partial_: true
+        eps: 1e-6
+        normalized_shape: ${common.dmodel}
+
+      attention_fn:
+        _target_: src.projected_compression.model.OlmoAttention
+        _partial_: true
+        dmodel: ${common.dmodel}
+        q_heads: ${common.q_heads}
+        kv_heads: ${common.kv_heads}
+        seq_len: ${common.sequence_length}
+        q_proj_fn:
+          _target_: src.projected_compression.model.Linear
+          _partial_: true
+          in_features: ${common.dmodel}
+          out_features: ${eval:'${common.dhead} * ${model.encoder.block_fn.attention_fn.q_heads}'}
+          partial_init_fn:
+            _target_: src.projected_compression.model.llm_random_weight_init
+            _partial_: true
+            scale: 1
+
+        k_proj_fn:
+          _target_: src.projected_compression.model.Linear
+          _partial_: true
+          in_features: ${common.dmodel}
+          out_features: ${eval:'${common.dhead} * ${model.encoder.block_fn.attention_fn.kv_heads}'}
+          partial_init_fn:
+            _target_: src.projected_compression.model.llm_random_weight_init
+            _partial_: true
+            scale: 1
+
+        v_proj_fn: ${model.encoder.block_fn.attention_fn.k_proj_fn}
+
+        o_proj_fn:
+          _target_: src.projected_compression.model.Linear
+          _partial_: true
+          in_features: ${eval:'${common.dhead} * ${model.encoder.block_fn.attention_fn.q_heads}'}
+          out_features: ${common.dmodel}
+          partial_init_fn:
+            _target_: src.projected_compression.model.llm_random_weight_init
+            _partial_: true
+            scale: 1
+
+        q_norm_fn:
+          _target_: src.core.model.RMSNorm
+          _partial_: true
+          eps: 1e-6
+          normalized_shape: ${eval:'${common.dhead} * ${common.q_heads}'}
+
+        k_norm_fn:
+          _target_: src.core.model.RMSNorm
+          _partial_: true
+          eps: 1e-6
+          normalized_shape: ${eval:'${common.dhead} * ${common.kv_heads}'}
+
+        rope_base: 500000
+        rope_scale_freqs: false
+
+  head:
+    _target_: src.projected_compression.model.TransformerHead
+    linear_fn:
+      _target_: src.projected_compression.model.Linear
+      _partial_: true
+      in_features: ${common.dmodel}
+      out_features: ${model.embedding.vocab_size}
+      partial_init_fn:
+        _target_: src.projected_compression.model.llm_random_weight_init
+        _partial_: true
+        scale: 1
+    norm_fn:
+      _target_: src.core.model.RMSNorm
+      _partial_: true
+      eps: 1e-6
+      normalized_shape: ${common.dmodel}

--- a/configs/_model/olmo/base_pc_mem_eff.yaml
+++ b/configs/_model/olmo/base_pc_mem_eff.yaml
@@ -1,0 +1,251 @@
+common:
+  dmodel: ???
+  dff: ???
+  dhead: ???
+  sequence_length: ???
+  base_dmodel: ???
+  base_dff: ???
+  n_blocks: ???
+  q_heads: ???
+  kv_heads: ???
+
+init_model_opt_sched_fn:
+  _target_: src.projected_compression.initialization.init_pc_attributes
+  _partial_: true
+
+projected_compression:
+  source_model_for_distillation: false
+
+
+model:
+  _target_: src.projected_compression.mem_eff.MemoryEfficientProjectedCompression
+
+  cast_bfloat16: true # whether to cast bfloat16 when calculating compressed matrix
+
+  source_model:
+    _target_: src.projected_compression.model.LLM
+    embedding:
+      _target_: src.projected_compression.model.Embedding
+      num_embeddings: 100352
+      embedding_dim: ${common.base_dmodel}
+
+    encoder:
+      _target_: src.projected_compression.model.TransformerEncoder
+      n_blocks: ${common.n_blocks}
+      block_fn:
+        _target_: src.projected_compression.model.OlmoTransformerBlock
+        _partial_: true
+        norm_fn:
+          _target_: src.core.model.RMSNorm
+          _partial_: true
+          eps: 1e-6
+          normalized_shape: ${common.base_dmodel}
+
+        attention_fn:
+          _target_: src.projected_compression.model.OlmoAttention
+          _partial_: true
+          dmodel: ${common.base_dmodel}
+          q_heads: ${common.q_heads}
+          kv_heads: ${common.kv_heads}
+          seq_len: ${common.sequence_length}
+          q_proj_fn:
+            _target_: src.projected_compression.model.Linear
+            _partial_: true
+            in_features: ${common.base_dmodel}
+            out_features: ${eval:'${common.dhead} * ${model.source_model.encoder.block_fn.attention_fn.q_heads}'}
+            partial_init_fn:
+              _target_: src.projected_compression.model.llm_random_weight_init
+              _partial_: true
+              scale: 1
+
+          k_proj_fn:
+            _target_: src.projected_compression.model.Linear
+            _partial_: true
+            in_features: ${common.base_dmodel}
+            out_features: ${eval:'${common.dhead} * ${model.source_model.encoder.block_fn.attention_fn.kv_heads}'}
+            partial_init_fn:
+              _target_: src.projected_compression.model.llm_random_weight_init
+              _partial_: true
+              scale: 1
+
+          v_proj_fn: ${model.source_model.encoder.block_fn.attention_fn.k_proj_fn}
+
+          o_proj_fn:
+            _target_: src.projected_compression.model.Linear
+            _partial_: true
+            in_features: ${eval:'${common.dhead} * ${model.source_model.encoder.block_fn.attention_fn.q_heads}'}
+            out_features: ${common.base_dmodel}
+            partial_init_fn:
+              _target_: src.projected_compression.model.llm_random_weight_init
+              _partial_: true
+              scale: 1
+
+          q_norm_fn:
+            _target_: src.core.model.RMSNorm
+            _partial_: true
+            eps: 1e-6
+            normalized_shape: ${eval:'${common.dhead} * ${common.q_heads}'}
+
+          k_norm_fn:
+            _target_: src.core.model.RMSNorm
+            _partial_: true
+            eps: 1e-6
+            normalized_shape: ${eval:'${common.dhead} * ${common.kv_heads}'}
+
+          rope_base: 500000
+          rope_scale_freqs: false
+
+        ff_layer_fn:
+          _target_: src.projected_compression.model.ProjectedLlamaFeedForward
+          _partial_: true
+          ff_pre_act_fn:
+            _target_: src.projected_compression.model.Linear
+            _partial_: true
+            in_features: ${common.base_dmodel}
+            out_features: ${common.base_dff}
+            partial_init_fn:
+              _target_: src.projected_compression.model.llm_random_weight_init
+              _partial_: true
+              scale: 1
+          ff_post_act_fn:
+            _target_: src.projected_compression.model.Linear
+            _partial_: true
+            in_features: ${common.base_dff}
+            out_features: ${common.base_dmodel}
+            partial_init_fn:
+              _target_: src.projected_compression.model.llm_random_weight_init
+              _partial_: true
+              scale: 1
+          gate_fn: ${model.source_model.encoder.block_fn.ff_layer_fn.ff_pre_act_fn}
+
+    head:
+      _target_: src.projected_compression.model.TransformerHead
+      linear_fn:
+        _target_: src.projected_compression.model.Linear
+        _partial_: true
+        in_features: ${common.base_dmodel}
+        out_features: ${model.source_model.embedding.num_embeddings}
+        partial_init_fn:
+          _target_: src.projected_compression.model.llm_random_weight_init
+          _partial_: true
+          scale: 1
+      norm_fn:
+        _target_: src.core.model.RMSNorm
+        _partial_: true
+        eps: 1e-6
+        normalized_shape: ${common.base_dmodel}
+
+
+
+  target_model:
+    _target_: src.projected_compression.model.LLM
+    embedding:
+      _target_: src.projected_compression.model.Embedding
+      num_embeddings: 100352
+      embedding_dim: ${common.dmodel}
+
+    encoder:
+      _target_: src.projected_compression.model.TransformerEncoder
+      n_blocks: ${common.n_blocks}
+      block_fn:
+        _target_: src.projected_compression.model.OlmoTransformerBlock
+        _partial_: true
+        norm_fn:
+          _target_: src.core.model.RMSNorm
+          _partial_: true
+          eps: 1e-6
+          normalized_shape: ${common.dmodel}
+
+        attention_fn:
+          _target_: src.projected_compression.model.OlmoAttention
+          _partial_: true
+          dmodel: ${common.dmodel}
+          q_heads: ${common.q_heads}
+          kv_heads: ${common.kv_heads}
+          seq_len: ${common.sequence_length}
+          q_proj_fn:
+            _target_: src.projected_compression.model.Linear
+            _partial_: true
+            in_features: ${common.dmodel}
+            out_features: ${eval:'${common.dhead} * ${model.target_model.encoder.block_fn.attention_fn.q_heads}'}
+            partial_init_fn:
+              _target_: src.projected_compression.model.llm_random_weight_init
+              _partial_: true
+              scale: 1
+
+          k_proj_fn:
+            _target_: src.projected_compression.model.Linear
+            _partial_: true
+            in_features: ${common.dmodel}
+            out_features: ${eval:'${common.dhead} * ${model.target_model.encoder.block_fn.attention_fn.kv_heads}'}
+            partial_init_fn:
+              _target_: src.projected_compression.model.llm_random_weight_init
+              _partial_: true
+              scale: 1
+
+          v_proj_fn: ${model.target_model.encoder.block_fn.attention_fn.k_proj_fn}
+
+          o_proj_fn:
+            _target_: src.projected_compression.model.Linear
+            _partial_: true
+            in_features: ${eval:'${common.dhead} * ${model.target_model.encoder.block_fn.attention_fn.q_heads}'}
+            out_features: ${common.dmodel}
+            partial_init_fn:
+              _target_: src.projected_compression.model.llm_random_weight_init
+              _partial_: true
+              scale: 1
+
+          q_norm_fn:
+            _target_: src.core.model.RMSNorm
+            _partial_: true
+            eps: 1e-6
+            normalized_shape: ${eval:'${common.dhead} * ${common.q_heads}'}
+
+          k_norm_fn:
+            _target_: src.core.model.RMSNorm
+            _partial_: true
+            eps: 1e-6
+            normalized_shape: ${eval:'${common.dhead} * ${common.kv_heads}'}
+
+          rope_base: 500000
+          rope_scale_freqs: false
+
+        ff_layer_fn:
+          _target_: src.projected_compression.model.ProjectedLlamaFeedForward
+          _partial_: true
+          ff_pre_act_fn:
+            _target_: src.projected_compression.model.Linear
+            _partial_: true
+            in_features: ${common.dmodel}
+            out_features: ${common.dff}
+            partial_init_fn:
+              _target_: src.projected_compression.model.llm_random_weight_init
+              _partial_: true
+              scale: 1
+          ff_post_act_fn:
+            _target_: src.projected_compression.model.Linear
+            _partial_: true
+            in_features: ${common.dff}
+            out_features: ${common.dmodel}
+            partial_init_fn:
+              _target_: src.projected_compression.model.llm_random_weight_init
+              _partial_: true
+              scale: 1
+          gate_fn: ${model.target_model.encoder.block_fn.ff_layer_fn.ff_pre_act_fn}
+
+    head:
+      _target_: src.projected_compression.model.TransformerHead
+      linear_fn:
+        _target_: src.projected_compression.model.Linear
+        _partial_: true
+        in_features: ${common.dmodel}
+        out_features: ${model.target_model.embedding.num_embeddings}
+        partial_init_fn:
+          _target_: src.projected_compression.model.llm_random_weight_init
+          _partial_: true
+          scale: 1
+      norm_fn:
+        _target_: src.core.model.RMSNorm
+        _partial_: true
+        eps: 1e-6
+        normalized_shape: ${common.dmodel}

--- a/configs/_model/olmo/projected_mem_eff_1B.yaml
+++ b/configs/_model/olmo/projected_mem_eff_1B.yaml
@@ -1,0 +1,14 @@
+defaults:
+  - base_pc_mem_eff
+  - _self_
+
+common:
+  dmodel: 1344 # ~50% parameter compression
+  dff: 5376 # ~50% parameter compression
+  dhead: 128
+  sequence_length: 512
+  base_dmodel: 2048
+  base_dff: 8192
+  n_blocks: 16
+  q_heads: 16
+  kv_heads: 16

--- a/configs/_trainer/olmo.yaml
+++ b/configs/_trainer/olmo.yaml
@@ -1,0 +1,35 @@
+
+trainer:
+  _partial_: true
+  _target_: src.core.trainer.Trainer
+  eval_interval: 100
+  n_eval_steps: 10
+  gradient_accumulation_steps: 1
+  gradient_clipping: 1.0
+  n_steps: null
+  learning_rate: null
+  weight_decay: 0.1
+
+  scheduler:
+    _partial_: true
+    _target_: src.core.schedulers.get_cosine_scheduler_with_warmup
+    final_lr_fraction: 0.1
+    warmup_steps: ${eval:'int(${trainer.n_steps} * 0.01)'}
+
+  distributed:
+    fsdp2:
+      modules_to_shard:
+        - ${model.embedding._target_}
+        - ${model.encoder.block_fn._target_}
+        - ${model.head._target_}
+
+  train_dataloader:
+    dataset:
+      tokenize_fn:
+        _target_: src.core.datasets.olmo_tokenize_fn
+
+
+  eval_dataloader:
+    dataset:
+      tokenize_fn:
+        _target_: src.core.datasets.olmo_tokenize_fn

--- a/configs/_trainer/olmo_1B_distillation.yaml
+++ b/configs/_trainer/olmo_1B_distillation.yaml
@@ -1,0 +1,16 @@
+
+defaults:
+  - olmo_distillation
+
+common_distillation:
+  dmodel: 2048
+  dff: 8192
+  dhead: 128
+  n_blocks: 16
+  q_heads: 16
+  kv_heads: 16
+  vocab_size: 100352
+
+distillation:
+  load:
+    path: "allenai/OLMo-2-0425-1B"

--- a/configs/_trainer/olmo_distillation.yaml
+++ b/configs/_trainer/olmo_distillation.yaml
@@ -1,0 +1,175 @@
+
+common_distillation:
+  dmodel: ???
+  dff: ???
+  dhead: ???
+  n_blocks: ???
+  q_heads: ???
+  kv_heads: ???
+  vocab_size: ???
+
+distillation:
+  load:
+    type: huggingface_olmo
+    path: ???
+
+  teacher_model:
+    _target_: src.projected_compression.model.LLM
+
+    embedding:
+      _target_: src.projected_compression.model.TransformerEmbedding
+      vocab_size: ${common_distillation.vocab_size}
+      dmodel: ${common_distillation.dmodel}
+      init_fn:
+        _target_: src.projected_compression.model.trunc_normal_
+        _partial_: true
+
+    encoder:
+      _target_: src.projected_compression.model.TransformerEncoder
+      n_blocks: ${common_distillation.n_blocks}
+      block_fn:
+        _target_: src.projected_compression.model.OlmoTransformerBlock
+        _partial_: true
+        norm_fn:
+          _target_: src.core.model.RMSNorm
+          _partial_: true
+          eps: 1e-6
+          normalized_shape: ${common_distillation.dmodel}
+
+        attention_fn:
+          _target_: src.projected_compression.model.OlmoAttention
+          _partial_: true
+          dmodel: ${common_distillation.dmodel}
+          q_heads: ${common_distillation.q_heads}
+          kv_heads: ${common_distillation.kv_heads}
+          seq_len: ${common.sequence_length}
+          q_proj_fn:
+            _target_: src.projected_compression.model.Linear
+            _partial_: true
+            in_features: ${common_distillation.dmodel}
+            out_features: ${eval:'${common_distillation.dhead} * ${distillation.teacher_model.encoder.block_fn.attention_fn.q_heads}'}
+            partial_init_fn:
+              _target_: src.projected_compression.model.llm_random_weight_init
+              _partial_: true
+              scale: 1
+
+          k_proj_fn:
+            _target_: src.projected_compression.model.Linear
+            _partial_: true
+            in_features: ${common_distillation.dmodel}
+            out_features: ${eval:'${common_distillation.dhead} * ${distillation.teacher_model.encoder.block_fn.attention_fn.kv_heads}'}
+            partial_init_fn:
+              _target_: src.projected_compression.model.llm_random_weight_init
+              _partial_: true
+              scale: 1
+
+          v_proj_fn: ${distillation.teacher_model.encoder.block_fn.attention_fn.k_proj_fn}
+
+          o_proj_fn:
+            _target_: src.projected_compression.model.Linear
+            _partial_: true
+            in_features: ${eval:'${common_distillation.dhead} * ${distillation.teacher_model.encoder.block_fn.attention_fn.q_heads}'}
+            out_features: ${common_distillation.dmodel}
+            partial_init_fn:
+              _target_: src.projected_compression.model.llm_random_weight_init
+              _partial_: true
+              scale: 1
+
+          q_norm_fn:
+            _target_: src.core.model.RMSNorm
+            _partial_: true
+            eps: 1e-6
+            normalized_shape: ${eval:'${common_distillation.dhead} * ${common_distillation.q_heads}'}
+
+          k_norm_fn:
+            _target_: src.core.model.RMSNorm
+            _partial_: true
+            eps: 1e-6
+            normalized_shape: ${eval:'${common_distillation.dhead} * ${common_distillation.kv_heads}'}
+
+          rope_base: 500000
+          rope_scale_freqs: false
+
+        ff_layer_fn:
+          _target_: src.projected_compression.model.ProjectedLlamaFeedForward
+          _partial_: true
+          ff_pre_act_fn:
+            _target_: src.projected_compression.model.Linear
+            _partial_: true
+            in_features: ${common_distillation.dmodel}
+            out_features: ${common_distillation.dff}
+            partial_init_fn:
+              _target_: src.projected_compression.model.llm_random_weight_init
+              _partial_: true
+              scale: 1
+          ff_post_act_fn:
+            _target_: src.projected_compression.model.Linear
+            _partial_: true
+            in_features: ${common_distillation.dff}
+            out_features: ${common_distillation.dmodel}
+            partial_init_fn:
+              _target_: src.projected_compression.model.llm_random_weight_init
+              _partial_: true
+              scale: 1
+          gate_fn: ${distillation.teacher_model.encoder.block_fn.ff_layer_fn.ff_pre_act_fn}
+
+    head:
+      _target_: src.projected_compression.model.TransformerHead
+      linear_fn:
+        _target_: src.projected_compression.model.Linear
+        _partial_: true
+        in_features: ${common_distillation.dmodel}
+        out_features: ${common_distillation.vocab_size}
+        partial_init_fn:
+          _target_: src.projected_compression.model.llm_random_weight_init
+          _partial_: true
+          scale: 1
+      norm_fn:
+        _target_: src.core.model.RMSNorm
+        _partial_: true
+        eps: 1e-6
+        normalized_shape: ${common_distillation.dmodel}
+
+trainer:
+  _partial_: true
+  _target_: src.core.trainer_distillation.TrainerDistillation
+  distillation_alpha: 0.5
+  distillation_temperature: 1.0
+  distillation_loss_num_chunks: 8  # split the vocab loss over N token chunks to cap peak memory
+  eval_interval: 100
+  n_eval_steps: 10
+  gradient_accumulation_steps: 1
+  gradient_clipping: 1.0
+  n_steps: null
+  learning_rate: null
+  weight_decay: 0.1
+
+  scheduler:
+    _partial_: true
+    _target_: src.core.schedulers.get_cosine_scheduler_with_warmup
+    final_lr_fraction: 0.1
+    warmup_steps: ${eval:'int(${trainer.n_steps} * 0.01)'}
+
+  teacher_distributed:
+    fsdp2:
+      modules_to_shard:
+        - ${distillation.teacher_model.embedding._target_}
+        - ${distillation.teacher_model.encoder.block_fn._target_}
+        - ${distillation.teacher_model.head._target_}
+
+  distributed:
+    fsdp2:
+      modules_to_shard:
+        - ${model.embedding._target_}
+        - ${model.encoder.block_fn._target_}
+        - ${model.head._target_}
+
+  train_dataloader:
+    dataset:
+      tokenize_fn:
+        _target_: src.core.datasets.olmo_tokenize_fn
+
+  eval_dataloader:
+    dataset:
+      tokenize_fn:
+        _target_: src.core.datasets.olmo_tokenize_fn

--- a/configs/pc_project/olmo/olmo_conversion.yaml
+++ b/configs/pc_project/olmo/olmo_conversion.yaml
@@ -1,0 +1,42 @@
+# notebook for producing a PC checkpoint used for PC_memeff training
+
+defaults:
+  - ../../_misc@_here_: default
+  - ../../_cluster@_here_: lem
+  - ../../_model/olmo@_here_: 1B
+  - _self_
+
+
+trainer:
+  checkpoint:
+    load:
+      type: huggingface
+      path: "allenai/OLMo-2-0425-1B"
+
+    save:
+      path: /lustre/pd03/plgrid/plgllmefficont3/plgj321m/pc/olmo2_1b_in_nano.pt # CHANGE
+
+infrastructure:
+  metric_logger:
+    name: PC_save_pretrained_hf_to_nano
+    tags:
+      - nano
+      - pc
+      - save_pretrained
+      - olmo2
+
+  slurm:
+    job-name: ${infrastructure.metric_logger.name}
+    gres: gpu:hopper:1
+    time: "0-01:00:00"
+
+init_model_opt_sched_fn:
+  _target_: src.core.olmo.save_pretrained_olmo_as_nano
+  _partial_: true
+
+# verify converted nano model matches HF logits; comment out to switch off
+apply_functions:
+  - _target_: src.core.olmo.verify_olmo_against_hf
+    _partial_: true
+    hf_path: ${trainer.checkpoint.load.path}
+    vocab_size: ${model.embedding.vocab_size}

--- a/configs/pc_project/olmo/olmo_hp_distil.yaml
+++ b/configs/pc_project/olmo/olmo_hp_distil.yaml
@@ -1,0 +1,73 @@
+defaults:
+  - ../../_cluster@_here_: lem
+  - ../../_model/olmo@_here_: 1B
+  - ../../_trainer@_here_: olmo_1B_distillation
+  - ../../_dataset@_here_: fineweb
+  - ../../_checkpoints@_here_: none
+  - ../../_misc@_here_: default
+
+
+common:
+  sequence_length: 1024
+  batch_size: 512
+
+  # base: dmodel 2048, dff 8192
+  ^target_dmodel: [448, 960, 1344]
+  target_dff: "${eval:'${common.target_dmodel} * 4'}"
+
+
+trainer:
+  gradient_accumulation_steps: 8
+  ^n_steps:
+    # - 2048 # 1B tokens  <4.5h
+    - 4096 # 2B tokens    <9h
+    - 8192 # 4B tokens    <18h
+    - 16384 # 8B tokens   <36h
+
+  learning_rate: 11
+
+  scheduler:
+    warmup_steps: 40
+
+  original_llama_path: allenai/OLMo-2-0425-1B # reference HF model for the exporter
+
+  checkpoint:
+    load:
+      type: huggingface_olmo
+      path: "allenai/OLMo-2-0425-1B"
+    save:
+      type: hf_only
+      path: /lustre/pd03/plgrid/plgllmefficont3/plgj321m/pc/checkpoints/hp_distil/olmo2/1B # CHANGE
+
+  eval_interval: 0
+  eval_dataloader: None
+  train_dataloader:
+    dataset:
+      seed: 1000
+
+
+infrastructure:
+  metric_logger:
+    name: OLMo2_HP
+    tags:
+      - nano
+      - pc
+      - olmo2
+      - 1B
+      - hard_pruning
+      - distillation
+      - "${eval:'{2048:\"1B_train\",4096:\"2B_train\",8192:\"4B_train\",16384:\"8B_train\"}[${trainer.n_steps}]'}"
+      - "${eval:'{448:\"10p\",960:\"30p\",1344:\"50p\"}[${common.target_dmodel}]'}"
+
+  slurm:
+    job-name: ${infrastructure.metric_logger.name}
+    gres: gpu:hopper:4
+    time: "2-00:00:00"
+
+
+apply_functions:
+  - _target_: src.projected_compression.pruning.prune
+    _partial_: true
+    dimensions_importances_path: /lustre/pd03/plgrid/plgllmefficont3/plgj321m/pc/importances/olmo2/1B/minitron_dimensions_importances.pt # CHANGE - from olmo_importances
+    target_dmodel: ${common.target_dmodel}
+    target_dff: ${common.target_dff}

--- a/configs/pc_project/olmo/olmo_hp_lm.yaml
+++ b/configs/pc_project/olmo/olmo_hp_lm.yaml
@@ -1,0 +1,70 @@
+defaults:
+  - ../../_cluster@_here_: lem
+  - ../../_model/olmo@_here_: 1B
+  - ../../_trainer@_here_: olmo
+  - ../../_dataset@_here_: fineweb
+  - ../../_checkpoints@_here_: none
+  - ../../_misc@_here_: default
+
+
+common:
+  sequence_length: 1024
+  batch_size: 512
+
+  # base: dmodel 2048, dff 8192
+  ^target_dmodel: [448, 960, 1344]
+  target_dff: "${eval:'${common.target_dmodel} * 4'}"
+
+
+trainer:
+  gradient_accumulation_steps: 8
+  ^n_steps:
+    # - 2048 # 1B tokens  <3h
+    - 4096 # 2B tokens    <6h
+    - 8192 # 4B tokens    <12h
+    - 16384 # 8B tokens   <24h
+
+  learning_rate: 11
+
+  scheduler:
+    warmup_steps: 40
+
+  original_llama_path: allenai/OLMo-2-0425-1B # reference HF model for the exporter
+
+  checkpoint:
+    load:
+      type: huggingface_olmo
+      path: "allenai/OLMo-2-0425-1B"
+    save:
+      type: hf_only
+      path: /lustre/pd03/plgrid/plgllmefficont3/plgj321m/pc/checkpoints/hp/olmo2/1B # CHANGE
+
+  eval_interval: 0
+  eval_dataloader: None
+
+
+infrastructure:
+  metric_logger:
+    name: OLMo2_HP
+    tags:
+      - nano
+      - pc
+      - olmo2
+      - 1B
+      - hard_pruning
+      - lm_retraining
+      - "${eval:'{2048:\"1B_train\",4096:\"2B_train\",8192:\"4B_train\",16384:\"8B_train\"}[${trainer.n_steps}]'}"
+      - "${eval:'{448:\"10p\",960:\"30p\",1344:\"50p\"}[${common.target_dmodel}]'}"
+
+  slurm:
+    job-name: ${infrastructure.metric_logger.name}
+    gres: gpu:hopper:4
+    time: "2-00:00:00"
+
+
+apply_functions:
+  - _target_: src.projected_compression.pruning.prune
+    _partial_: true
+    dimensions_importances_path: /lustre/pd03/plgrid/plgllmefficont3/plgj321m/pc/importances/olmo2/1B/minitron_dimensions_importances.pt # CHANGE - from olmo_importances
+    target_dmodel: ${common.target_dmodel}
+    target_dff: ${common.target_dff}

--- a/configs/pc_project/olmo/olmo_importances.yaml
+++ b/configs/pc_project/olmo/olmo_importances.yaml
@@ -1,0 +1,72 @@
+defaults:
+  - ../../_cluster@_here_: lem
+  - ../../_model/olmo@_here_: 1B
+  - ../../_trainer@_here_: olmo
+  - ../../_dataset@_here_: fineweb
+  - ../../_checkpoints@_here_: none
+  - ../../_misc@_here_: default
+
+
+common:
+  sequence_length: 1024
+  batch_size: 4
+
+
+trainer:
+  gradient_accumulation_steps: 8 # not used ?
+  n_steps: 0 # not used
+  learning_rate: 1 # not used
+
+  checkpoint:
+    load:
+      type: huggingface_olmo
+      path: "allenai/OLMo-2-0425-1B"
+
+    save:
+      type: nano
+      path: /lustre/pd03/plgrid/plgllmefficont3/plgj321m/pc/importances/olmo2/1B # CHANGE
+
+
+infrastructure:
+  metric_logger:
+    name: OLMo2_importances
+    tags:
+      - nano
+      - pc
+      - olmo2
+      - 1B
+      - IMPORTANCES
+      - fineweb
+
+  slurm:
+    job-name: importances_olmo2
+    gres: gpu:hopper:1
+    nodes: 1
+    time: "0-2:00:00"
+
+
+apply_functions:
+  - _target_: src.projected_compression.weight_importances.dummy_importances
+    _partial_: true
+    dmodel: ${common.dmodel}
+    dff: ${common.dff}
+    n_blocks: ${model.encoder.n_blocks}
+    checkpoint_save_path: ${trainer.checkpoint.save.path}
+  - _target_: src.projected_compression.weight_importances.minitron_importances
+    _partial_: true
+    dataloader: ${trainer.train_dataloader}
+    dmodel: ${common.dmodel}
+    dff: ${common.dff}
+    calibration_dataset_size: 8192 # nvidia used 2k steps of 4k sequence lenght - this is the saturaion poin - longer doesnt improve miningfully
+    seq_len: ${common.sequence_length}
+    total_batch_size: ${trainer.train_dataloader.total_batch_size}
+    n_blocks: ${model.encoder.n_blocks}
+    checkpoint_save_path: ${trainer.checkpoint.save.path}
+  - _target_: src.projected_compression.weight_importances.magnitude_importances
+    _partial_: true
+    dmodel: ${common.dmodel}
+    dff: ${common.dff}
+    n_blocks: ${model.encoder.n_blocks}
+    checkpoint_save_path: ${trainer.checkpoint.save.path}
+  - _target_: src.core.utils.finish_exp
+    _partial_: true

--- a/configs/pc_project/olmo/olmo_pc_distil.yaml
+++ b/configs/pc_project/olmo/olmo_pc_distil.yaml
@@ -1,0 +1,98 @@
+defaults:
+  - ../../_cluster@_here_: lem
+  - ../../_model/olmo@_here_: projected_mem_eff_1B
+  - ../../_trainer@_here_: olmo_1B_distillation
+  - ../../_dataset@_here_: fineweb
+  - ../../_checkpoints@_here_: none
+  - ../../_misc@_here_: default
+
+common:
+  sequence_length: 1024
+  batch_size: 512
+
+  # base: dmodel 2048, dff 8192
+  ^dmodel: [448, 960, 1344]
+  dff: "${eval:'${common.dmodel} * 4'}"
+
+
+trainer:
+  _target_: src.projected_compression.trainer_distillation.PCDistillationTrainer
+  gradient_accumulation_steps: 8
+  ^n_steps:
+    - 2048 # 1B tokens  <5h
+    # - 4096 # 2B tokens    <10h
+    # - 8192 # 4B tokens    <20h
+    # - 16384 # 8B tokens   <40h
+
+  gradient_clipping: 0.25 #best
+  only_compress_model_gradient_clipping: false
+  only_target_model_gradient_clipping: 1.0 #best
+
+  learning_rate: 14
+
+  scheduler:
+    warmup_steps: 40
+
+  distributed:
+    fsdp2: null
+
+  original_llama_path: allenai/OLMo-2-0425-1B # reference HF model for the exporter
+
+  eval_interval: 0 # PC_memeff does not work in eval inference mode
+  eval_dataloader: None
+
+  checkpoint: # only way to save PC_memeff model
+    save:
+      interval: 0  # 0 = only save at the end of training
+      model_checkpoint_filename: __model_checkpoint_filename.pt
+      path: /lustre/pd03/plgrid/plgllmefficont3/plgj321m/pc/checkpoints/pc_distil/olmo2/1B # CHANGE
+      training_state_filename: __training_state_filename.pt
+      type: hf_only
+
+projected_compression:
+  modules_to_shard:
+    - src.projected_compression.mem_eff.CompressibleBlock
+    - ${model.source_model.embedding._target_}
+    - ${model.source_model.encoder.block_fn._target_}
+    - ${model.source_model.head._target_}
+
+  source_model_path: /lustre/pd03/plgrid/plgllmefficont3/plgj321m/pc/olmo2_1b_in_nano.pt # CHANGE - from olmo_conversion
+  path_to_importances: /lustre/pd03/plgrid/plgllmefficont3/plgj321m/pc/importances/olmo2/1B/minitron_dimensions_importances.pt # CHANGE - from olmo_importances
+
+  init_norms_with_ones: false
+
+  separate_block_optimizers: true
+
+  pc_weights_lr_ratio: 1.0 # lr multiplier for projection matrices (not aux weights)
+
+  adjust_grad_norm: false
+
+  cpu_offload_projections: false
+
+  source_model_for_distillation: true
+
+distillation:
+  load:
+    type: pc_memeff_base # uses internal teacher model representation for distillation to save memory - source_model_for_distillation: true
+
+model:
+  cast_bfloat16: true # whether to cast bfloat16 when calculating compressed matrix
+
+infrastructure:
+  metric_logger:
+    name: OLMo2_PC
+    tags:
+      - nano
+      - pc
+      - olmo2
+      - 1B
+      - projected_compression
+      - distillation
+      - "${eval:'{2048:\"1B_train\",4096:\"2B_train\",8192:\"4B_train\",16384:\"8B_train\"}[${trainer.n_steps}]'}"
+      - mem_eff
+      - "${eval:'{448:\"10p\",960:\"30p\",1344:\"50p\"}[${common.dmodel}]'}"
+
+  slurm:
+    job-name: ${infrastructure.metric_logger.name}
+    gres: gpu:hopper:4
+    time: "2-12:00:00"

--- a/configs/pc_project/olmo/olmo_pc_lm.yaml
+++ b/configs/pc_project/olmo/olmo_pc_lm.yaml
@@ -1,0 +1,90 @@
+defaults:
+  - ../../_cluster@_here_: lem
+  - ../../_model/olmo@_here_: projected_mem_eff_1B
+  - ../../_trainer@_here_: olmo
+  - ../../_dataset@_here_: fineweb
+  - ../../_checkpoints@_here_: none
+  - ../../_misc@_here_: default
+
+common:
+  sequence_length: 1024
+  batch_size: 512
+
+  # base: dmodel 2048, dff 8192
+  ^dmodel: [448, 960, 1344]
+  dff: "${eval:'${common.dmodel} * 4'}"
+
+
+trainer:
+  _target_: src.projected_compression.trainer.PCTrainer
+  gradient_accumulation_steps: 8
+  ^n_steps:
+    - 2048 # 1B tokens  <3h
+    # - 4096 # 2B tokens    <6h
+    # - 8192 # 4B tokens    <12h
+    # - 16384 # 8B tokens   <24h
+
+  gradient_clipping: 1.0 # match HP baseline clip
+  only_compress_model_gradient_clipping: false
+  only_target_model_gradient_clipping: 1.0 #best
+
+  learning_rate: 13
+
+  scheduler:
+    warmup_steps: 40
+
+  distributed:
+    fsdp2: null
+
+  eval_dataloader: None
+  eval_interval: 0
+
+  original_llama_path: allenai/OLMo-2-0425-1B
+  checkpoint:
+    save: #switch
+      interval: 0  # 0 = only save at the end of training
+      path: /lustre/pd03/plgrid/plgllmefficont3/plgj321m/pc/checkpoints/pc/olmo2/1B # CHANGE
+      training_state_filename: __training_state_filename.pt
+      type: hf_only  # "nano" | "hf_only" | "nano_and_hf"
+
+projected_compression:
+  modules_to_shard:
+    - src.projected_compression.mem_eff.CompressibleBlock
+    - ${model.source_model.embedding._target_}
+    - ${model.source_model.encoder.block_fn._target_}
+    - ${model.source_model.head._target_}
+
+  source_model_path: /lustre/pd03/plgrid/plgllmefficont3/plgj321m/pc/olmo2_1b_in_nano.pt # CHANGE - from olmo_conversion
+  path_to_importances: /lustre/pd03/plgrid/plgllmefficont3/plgj321m/pc/importances/olmo2/1B/minitron_dimensions_importances.pt # CHANGE - from olmo_importances
+
+  init_norms_with_ones: false
+
+  separate_block_optimizers: true
+
+  adjust_grad_norm: false
+
+  cpu_offload_projections: false
+
+
+model:
+  cast_bfloat16: false
+
+infrastructure:
+  metric_logger:
+    name: OLMo2_PC
+    tags:
+      - nano
+      - pc
+      - olmo2
+      - 1B
+      - projected_compression
+      - mem_eff
+      - "${eval:'{2048:\"1B_train\",4096:\"2B_train\",8192:\"4B_train\",16384:\"8B_train\"}[${trainer.n_steps}]'}"
+      - lm_retraining
+      - "${eval:'{448:\"10p\",960:\"30p\",1344:\"50p\"}[${common.dmodel}]'}"
+      - fp32
+
+  slurm:
+    job-name: ${infrastructure.metric_logger.name}
+    gres: gpu:hopper:4
+    time: "1-00:00:00"

--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ from src.core.distributed_training import setup_distributed_training
 from src.core.conversion_from_llmrandom import load_llmrandom_checkpoint
 from src.core.llama import copy_llama_model_weights_from_HF
 from src.core.qwen import copy_qwen_model_weights_from_HF
+from src.core.olmo import copy_olmo_model_weights_from_HF
 from grid_generator.generate_configs import create_grid_config
 from grid_generator.sbatch_builder import generate_sbatch_script
 import resolver as _  # I should be able to ignore this line by linter, but ~ things like # ignore did not work
@@ -268,6 +269,11 @@ def initialize_training_components(cfg: OmegaConf, metric_logger=None):
         model, optimizer, scheduler = get_model_optimizer_scheduler(
             cfg, model, learning_rate
         )
+    elif cfg.trainer.checkpoint.load.type == "huggingface_olmo":
+        copy_olmo_model_weights_from_HF(model, cfg.trainer.checkpoint.load.path)
+        model, optimizer, scheduler = get_model_optimizer_scheduler(
+            cfg, model, learning_rate
+        )
     elif cfg.trainer.checkpoint.load.type == "llm-random":
         load_llmrandom_checkpoint(cfg.trainer.checkpoint.load, model)
         model, optimizer, scheduler = get_model_optimizer_scheduler(
@@ -325,12 +331,20 @@ def run(cfg: OmegaConf, metric_logger=None):
         trainer = instantiate(cfg.trainer)
 
         if "distillation" in cfg:
-            if cfg.distillation.load.type in ["huggingface", "huggingface_qwen"]:
+            if cfg.distillation.load.type in [
+                "huggingface",
+                "huggingface_qwen",
+                "huggingface_olmo",
+            ]:
                 teacher_model = instantiate(
                     cfg.distillation.teacher_model, _convert_="all"
                 ).to(get_device())
                 if cfg.distillation.load.type == "huggingface_qwen":
                     copy_qwen_model_weights_from_HF(
+                        teacher_model, cfg.distillation.load.path
+                    )
+                elif cfg.distillation.load.type == "huggingface_olmo":
+                    copy_olmo_model_weights_from_HF(
                         teacher_model, cfg.distillation.load.path
                     )
                 else:

--- a/src/core/datasets.py
+++ b/src/core/datasets.py
@@ -70,6 +70,25 @@ def qwen_tokenize_fn():
     return tokenize_function
 
 
+def olmo_tokenize_fn():
+    tokenizer = AutoTokenizer.from_pretrained("allenai/OLMo-2-0425-1B")
+    eos_id = tokenizer.eos_token_id
+
+    def tokenize_function(examples):
+        batch_encodings = tokenizer(
+            examples["text"],
+            truncation=False,
+            max_length=int(1e10),
+        )
+        # OLMo's fast tokenizer has no add_eos_token flag; append eos to bound documents
+        batch_encodings["input_ids"] = [
+            ids + [eos_id] for ids in batch_encodings["input_ids"]
+        ]
+        return batch_encodings
+
+    return tokenize_function
+
+
 def smollm_135_tokenize_fn():
     tokenizer = AutoTokenizer.from_pretrained(
         "HuggingFaceTB/SmolLM-135M",

--- a/src/core/olmo.py
+++ b/src/core/olmo.py
@@ -1,0 +1,135 @@
+from collections import OrderedDict
+import re
+
+import torch
+from omegaconf import OmegaConf
+from hydra.utils import instantiate
+from transformers import AutoModelForCausalLM
+
+
+def remap_olmo2hf_state_dict_to_nano(olmo_state_dict):
+    """Remap an OLMo2 HF state dict onto the nano naming.
+
+    OLMo2 uses reordered (post) normalization, so its two per-layer norms map to the
+    residual norms differently than Llama:
+      post_attention_layernorm   -> attention residual norm (applied after attention)
+      post_feedforward_layernorm -> ff residual norm (applied after the MLP)
+    It also carries full-dim QK-norm (q_norm / k_norm) and no input_layernorm.
+    """
+    remapped = {}
+    for key, value in olmo_state_dict.items():
+        new_key = key
+
+        new_key = new_key.replace("model.embed_tokens.weight", "embedding.weight")
+        new_key = new_key.replace("model.norm.weight", "head.norm.weight")
+        new_key = new_key.replace("lm_head.weight", "head.linear.weight")
+
+        layer_match = re.match(r"model\.layers\.(\d+)\.(.*)", new_key)
+        if layer_match:
+            layer_num = layer_match.group(1)
+            sub_key = layer_match.group(2)
+
+            # Attention projections
+            sub_key = sub_key.replace(
+                "self_attn.q_proj.weight", "attention_layer.layer.q_proj.weight"
+            )
+            sub_key = sub_key.replace(
+                "self_attn.k_proj.weight", "attention_layer.layer.k_proj.weight"
+            )
+            sub_key = sub_key.replace(
+                "self_attn.v_proj.weight", "attention_layer.layer.v_proj.weight"
+            )
+            sub_key = sub_key.replace(
+                "self_attn.o_proj.weight", "attention_layer.layer.o_proj.weight"
+            )
+
+            # Full-dim QK-norm
+            sub_key = sub_key.replace(
+                "self_attn.q_norm.weight", "attention_layer.layer.q_norm.weight"
+            )
+            sub_key = sub_key.replace(
+                "self_attn.k_norm.weight", "attention_layer.layer.k_norm.weight"
+            )
+
+            # Reordered norms (post-attention / post-feedforward)
+            sub_key = sub_key.replace(
+                "post_attention_layernorm.weight", "attention_layer.norm.weight"
+            )
+            sub_key = sub_key.replace(
+                "post_feedforward_layernorm.weight", "ff_layer.norm.weight"
+            )
+
+            # MLP
+            sub_key = sub_key.replace(
+                "mlp.up_proj.weight", "ff_layer.layer.ff_pre_act.weight"
+            )
+            sub_key = sub_key.replace(
+                "mlp.gate_proj.weight", "ff_layer.layer.gate.weight"
+            )
+            sub_key = sub_key.replace(
+                "mlp.down_proj.weight", "ff_layer.layer.ff_post_act.weight"
+            )
+
+            new_key = f"encoder.blocks.{layer_num}.{sub_key}"
+
+        remapped[new_key] = value
+
+    return OrderedDict(remapped)
+
+
+def copy_olmo_model_weights_from_HF(model, path):
+    hf_model = AutoModelForCausalLM.from_pretrained(path)
+    remapped_state_dict = remap_olmo2hf_state_dict_to_nano(hf_model.state_dict())
+    model.load_state_dict(remapped_state_dict)
+
+
+def save_pretrained_olmo_as_nano(cfg: OmegaConf, metric_logger=None):
+
+    hf_model = AutoModelForCausalLM.from_pretrained(cfg.trainer.checkpoint.load.path)
+    nano_sd = remap_olmo2hf_state_dict_to_nano(hf_model.state_dict())
+    # PC mem-eff projections run in fp32 (cast_bfloat16=false); cast here so the source
+    # checkpoint matches the Llama pipeline's fp32 checkpoint regardless of HF dtype
+    nano_sd = OrderedDict((k, v.float()) for k, v in nano_sd.items())
+
+    model = instantiate(cfg.model, _convert_="all")
+    weights = {k for k in model.state_dict() if not k.endswith((".sin", ".cos"))}
+    missing = weights - set(nano_sd)
+    if missing:
+        raise RuntimeError(f"OLMo2->nano remap left weights unfilled: {sorted(missing)}")
+
+    model.load_state_dict(nano_sd, strict=False, assign=True)
+
+    torch.save(model.state_dict(), cfg.trainer.checkpoint.save.path)
+
+    if cfg.get("apply_functions", None):
+        for fn in instantiate(cfg.apply_functions):
+            fn(model)
+
+    return None, None, None, None, None
+
+
+def verify_olmo_against_hf(model, hf_path, vocab_size, seq_len=256, min_agreement=0.99):
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    hf_model = AutoModelForCausalLM.from_pretrained(hf_path).to(device).eval().float()
+    model = model.to(device).eval().float()
+
+    torch.manual_seed(0)
+    input_ids = torch.randint(0, vocab_size, (1, seq_len), device=device)
+
+    with torch.no_grad():
+        nano_logits = model(input_ids)
+        hf_logits = hf_model(input_ids).logits
+
+    max_abs_diff = (nano_logits - hf_logits).abs().max().item()
+    argmax_agreement = (
+        (nano_logits.argmax(-1) == hf_logits.argmax(-1)).float().mean().item()
+    )
+    print(
+        f"[verify] max_abs_logit_diff={max_abs_diff:.4g} "
+        f"argmax_agreement={argmax_agreement:.4f} over {seq_len} positions"
+    )
+    if argmax_agreement < min_agreement:
+        raise RuntimeError(
+            f"OLMo2->nano verification failed: argmax_agreement={argmax_agreement:.4f} "
+            f"< {min_agreement} (max_abs_logit_diff={max_abs_diff:.4g})"
+        )

--- a/src/projected_compression/convert_memeff_to_hf.py
+++ b/src/projected_compression/convert_memeff_to_hf.py
@@ -1,4 +1,10 @@
-from transformers import AutoConfig, LlamaForCausalLM, Qwen3ForCausalLM, AutoTokenizer
+from transformers import (
+    AutoConfig,
+    LlamaForCausalLM,
+    Qwen3ForCausalLM,
+    Olmo2ForCausalLM,
+    AutoTokenizer,
+)
 from src.core.metric_loggers import get_metric_logger
 from src.projected_compression.initialization import create_model
 import torch.distributed.checkpoint as dcp
@@ -148,10 +154,81 @@ def load_pc_state_dict_to_qwen(state_dict, original_qwen):
     return qwen
 
 
+def load_pc_state_dict_to_olmo(state_dict, original_olmo):
+    conf = AutoConfig.from_pretrained(original_olmo)
+
+    # num_hidden_layers / num_attention_heads / num_key_value_heads / head_dim unchanged;
+    # only the residual stream (hidden_size) and ff (intermediate_size) are compressed.
+    conf.hidden_size = state_dict["encoder.blocks.0.attention_layer.norm.weight"].shape[
+        0
+    ]
+    conf.intermediate_size = state_dict[
+        "encoder.blocks.0.ff_layer.layer.gate.weight"
+    ].shape[0]
+    conf.torch_dtype = None
+    # compressed model has independent embedding and lm_head (different projections)
+    conf.tie_word_embeddings = False
+
+    olmo = Olmo2ForCausalLM(conf)
+
+    new_state_dict = {
+        "model.embed_tokens.weight": state_dict["embedding"],
+        "model.norm.weight": state_dict["head.norm.weight"],
+        "lm_head.weight": state_dict["head.linear.weight"],
+    }
+
+    for layer in range(conf.num_hidden_layers):
+        prefix_src = f"encoder.blocks.{layer}."
+        prefix_tgt = f"model.layers.{layer}."
+
+        # attention
+        new_state_dict[f"{prefix_tgt}self_attn.q_proj.weight"] = state_dict[
+            f"{prefix_src}attention_layer.layer.q_proj.weight"
+        ]
+        new_state_dict[f"{prefix_tgt}self_attn.k_proj.weight"] = state_dict[
+            f"{prefix_src}attention_layer.layer.k_proj.weight"
+        ]
+        new_state_dict[f"{prefix_tgt}self_attn.v_proj.weight"] = state_dict[
+            f"{prefix_src}attention_layer.layer.v_proj.weight"
+        ]
+        new_state_dict[f"{prefix_tgt}self_attn.o_proj.weight"] = state_dict[
+            f"{prefix_src}attention_layer.layer.o_proj.weight"
+        ]
+        # OLMo2 full-dim QK-norm (q_heads*dhead / kv_heads*dhead, not compressed)
+        new_state_dict[f"{prefix_tgt}self_attn.q_norm.weight"] = state_dict[
+            f"{prefix_src}attention_layer.layer.q_norm.weight"
+        ]
+        new_state_dict[f"{prefix_tgt}self_attn.k_norm.weight"] = state_dict[
+            f"{prefix_src}attention_layer.layer.k_norm.weight"
+        ]
+        # mlp
+        new_state_dict[f"{prefix_tgt}mlp.gate_proj.weight"] = state_dict[
+            f"{prefix_src}ff_layer.layer.gate.weight"
+        ]
+        new_state_dict[f"{prefix_tgt}mlp.up_proj.weight"] = state_dict[
+            f"{prefix_src}ff_layer.layer.ff_pre_act.weight"
+        ]
+        new_state_dict[f"{prefix_tgt}mlp.down_proj.weight"] = state_dict[
+            f"{prefix_src}ff_layer.layer.ff_post_act.weight"
+        ]
+        # OLMo2 reordered norms: post-attention and post-feedforward
+        new_state_dict[f"{prefix_tgt}post_attention_layernorm.weight"] = state_dict[
+            f"{prefix_src}attention_layer.norm.weight"
+        ]
+        new_state_dict[f"{prefix_tgt}post_feedforward_layernorm.weight"] = state_dict[
+            f"{prefix_src}ff_layer.norm.weight"
+        ]
+
+    olmo.load_state_dict(new_state_dict, strict=True)
+    return olmo
+
+
 def _load_pc_state_dict_to_hf(state_dict, original_path):
-    """Dispatch to the Qwen or Llama exporter based on the presence of QK-norm."""
-    is_qwen = any("attention_layer.layer.q_norm.weight" in k for k in state_dict)
-    if is_qwen:
+    """Dispatch to the Qwen / OLMo2 / Llama exporter based on the source HF arch."""
+    model_type = AutoConfig.from_pretrained(original_path).model_type
+    if model_type == "olmo2":
+        return load_pc_state_dict_to_olmo(state_dict, original_path)
+    if model_type in ("qwen3", "qwen2"):
         return load_pc_state_dict_to_qwen(state_dict, original_path)
     return load_pc_state_dict_to_llama(state_dict, original_path)
 

--- a/src/projected_compression/model.py
+++ b/src/projected_compression/model.py
@@ -319,6 +319,91 @@ class QwenAttention(RoPEAttention):
         return output
 
 
+class OlmoAttention(RoPEAttention):
+    """RoPEAttention plus OLMo2 QK-RMSNorm over the full q/k projection.
+
+    Unlike Qwen (per-head dhead norm applied after the head reshape), OLMo2 norms
+    the whole q_proj/k_proj output (q_heads*dhead / kv_heads*dhead) before reshaping
+    into heads, and the projections read the raw residual stream (post-norm block).
+    """
+
+    def __init__(self, *args, q_norm_fn, k_norm_fn, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.q_norm = q_norm_fn()
+        self.k_norm = k_norm_fn()
+
+    def forward(self, x):
+        query_states = self.q_norm(self.q_proj(x))
+        key_states = self.k_norm(self.k_proj(x))
+        value_states = self.v_proj(x)
+
+        batch, seq_len = x.shape[:-1]
+        q = query_states.view(batch, seq_len, self.q_heads, -1).transpose(1, 2)
+        q = self.rope(q)
+        k = key_states.view(batch, seq_len, self.kv_heads, -1).transpose(1, 2)
+        k = self.rope(k)
+
+        v = value_states.view(batch, seq_len, self.kv_heads, -1).transpose(1, 2)
+
+        k = repeat_kv(k, self.q_heads // self.kv_heads)
+        v = repeat_kv(v, self.q_heads // self.kv_heads)
+        attention_output = self.attention_mechanism(
+            query=q, key=k, value=v, causal=True
+        )
+
+        output = self.o_proj(attention_output.transpose(1, 2).contiguous().flatten(-2))
+
+        return output
+
+
+class PostNormResidual(Residual):
+    """OLMo2-style residual: out = norm(layer(x)) + x (norm on the sublayer output)."""
+
+    def forward(self, x):
+        out = self.norm(self.layer(x))
+        if self.metric_logger is not None:
+            self.metric_logger.accumulate_metrics(
+                layer_name=f"{self.log_name}",
+                transform_fn=Residual.intermediate_norms,
+                calculate_fn=Residual.calculate_metrics,
+                metrics={
+                    "residual_stream": x,
+                    "updates": out,
+                },
+            )
+        return out + x
+
+
+class OlmoTransformerBlock(nn.Module):
+    """TransformerBlock with post-normalization (OLMo2 reordered norm placement)."""
+
+    def __init__(
+        self,
+        block_id,
+        norm_fn,
+        attention_fn,
+        ff_layer_fn,
+    ):
+        super().__init__()
+        self.log_name = f"block[{block_id}]"
+
+        self.attention_layer = PostNormResidual(
+            norm=norm_fn(),
+            layer=attention_fn(),
+            log_name=f"{self.log_name}/residual_attention",
+        )
+        self.ff_layer = PostNormResidual(
+            norm=norm_fn(),
+            layer=ff_layer_fn(),
+            log_name=f"{self.log_name}/residual_feedforward",
+        )
+
+    def forward(self, x):
+        x = self.attention_layer(x)
+        x = self.ff_layer(x)
+        return x
+
+
 class FeedForward(nn.Module):
     def __init__(self, ff_pre_act_fn, ff_post_act_fn):
         super().__init__()


### PR DESCRIPTION
OLMo-2 differs from Llama/Qwen in two ways, both confined to the plain model: reordered (post) normalization and QK-norm over the full q/k projection.

- model.py: OlmoAttention (full-dim QK-RMSNorm before head reshape), PostNormResidual (out = norm(layer(x)) + x), OlmoTransformerBlock
- src/core/olmo.py: HF->nano remap (post_attention/post_feedforward_layernorm routing, full-dim QK-norm), copy/save_pretrained/verify helpers
- main.py: huggingface_olmo load dispatch (LM + distillation teacher)
- convert_memeff_to_hf.py: Olmo2 exporter; dispatch now keys off HF model_type (olmo2/qwen3/llama) instead of QK-norm presence
- datasets.py: olmo_tokenize_fn
- configs/_model/olmo/, configs/_trainer/olmo*, configs/pc_project/olmo/ (conversion, importances, pc_lm, pc_distil, hp_lm, hp_distil) mirroring qwen

The PC compression machinery (mem_eff, initialization) is norm-placement- and QK-norm-shape-agnostic, so no changes were needed there.

Verified locally (no cluster): tiny random Olmo2 nano-vs-HF logit match exact (argmax=1.0, diff 3.9e-7) exercising post-norm + full-dim QK-norm + GQA; real OLMo-2-1B checkpoint (179 params) maps with zero missing/extra keys; PC source/target sub-models instantiate and forward (source ~1.48B).